### PR TITLE
Add 'CALL' and 'LOAD' to dangerous keywords list

### DIFF
--- a/packages/seekdb/src/collection.ts
+++ b/packages/seekdb/src/collection.ts
@@ -88,6 +88,8 @@ export class Collection {
       "DUMPFILE",
       "INTO OUTFILE",
       "INTO DUMPFILE",
+      "CALL",
+      "LOAD"
     ];
 
     for (const keyword of dangerousKeywords) {


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
This PR adds CALL and LOAD to the dangerous keywords list to enhance SQL execution safety.




## Solution Description
The following keywords have been added to the dangerous keyword registry:

CALL: Used to execute stored procedures or routines, which may contain complex logic or sensitive operations.
LOAD: Used for bulk data loading (e.g., LOAD DATA), which could potentially be exploited for unauthorized data injection or file system access.
