### PR TITLE
chore(seekdb): improve diagnostics for Windows embedded test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,7 @@ jobs:
           SEEKDB_USER: root
           SEEKDB_PASSWORD: ""
           SEEKDB_DATABASE: test
+          SEEKDB_DEBUG_SQL: "1"
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
             pnpm run test:embedded 2>&1 | tee /tmp/vitest.log

--- a/packages/bindings/scripts/libseekdb_url_config.py
+++ b/packages/bindings/scripts/libseekdb_url_config.py
@@ -1,6 +1,6 @@
 # libseekdb zip download URL config
 
-LIBSEEKDB_URL_PREFIX = "https://oceanbase-seekdb-builds.s3.ap-southeast-1.amazonaws.com/libseekdb/all_commits/7cdd3bc802ece1d005553ddfbc0d4f3eb6993fe9/"
+LIBSEEKDB_URL_PREFIX = "https://oceanbase-seekdb-builds.s3.ap-southeast-1.amazonaws.com/libseekdb/all_commits/252658b83822d6ea065d9d8598520a2fd12d2444/"
 
 # LIBSEEKDB_URL_PREFIX = "https://github.com/oceanbase/seekdb/releases/download/v1.1.0/"
 

--- a/packages/seekdb/src/internal-client-embedded.ts
+++ b/packages/seekdb/src/internal-client-embedded.ts
@@ -80,7 +80,25 @@ export class InternalEmbeddedClient implements IInternalClient {
   ): Promise<RowDataPacket[] | null> {
     const conn = await this._ensureConnection();
     const addon = this._addon!;
-    const result = await addon.execute(conn, sql, params);
+    let result;
+    try {
+      result = await addon.execute(conn, sql, params);
+    } catch (error: unknown) {
+      // Surface SQL + first 8 params on native execute failure so CI logs can pinpoint the
+      // failing statement instead of just "Update execution failed".
+      if (process.env.SEEKDB_DEBUG_SQL || process.env.SEEKDB_DEBUG) {
+        const err = error as { message?: string };
+        const sqlPreview = sql.length > 500 ? `${sql.slice(0, 500)}...` : sql;
+        const paramsPreview = params
+          ? JSON.stringify(params.slice(0, 8)).slice(0, 500)
+          : "[]";
+        // eslint-disable-next-line no-console
+        console.error(
+          `[seekdb] execute failed: ${err.message ?? error}\n  sql=${sqlPreview}\n  params=${paramsPreview}`
+        );
+      }
+      throw error;
+    }
 
     if (!result || !result.rows) {
       return null;

--- a/packages/seekdb/tests/embedded/test-utils.ts
+++ b/packages/seekdb/tests/embedded/test-utils.ts
@@ -102,22 +102,40 @@ export async function cleanupTestDb(testFileName: string): Promise<void> {
 
   // Retry cleanup with exponential backoff
   const maxRetries = 5;
+  let lastError: any;
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     try {
       await fs.rm(testDbDir, { recursive: true, force: true });
-      // Success, exit retry loop
-      return;
+      // Verify directory is actually gone (fs.rm with force:true silently succeeds when dir
+      // doesn't exist OR when removal partially fails on Windows due to file locks).
+      try {
+        await fs.access(testDbDir);
+        // Directory still exists after rm — treat as failure to trigger retry.
+        throw new Error(
+          `cleanupTestDb: directory still exists after fs.rm: ${testDbDir}`
+        );
+      } catch (accessErr: any) {
+        if (accessErr?.code === "ENOENT") {
+          return; // gone, success
+        }
+        throw accessErr;
+      }
     } catch (error: any) {
-      // If it's the last attempt, ignore the error
+      lastError = error;
       if (attempt === maxRetries - 1) {
-        // Ignore if directory doesn't exist or other errors on final attempt
+        // Final attempt failed: surface the error so CI logs reveal cleanup leakage
+        // instead of silently masking it as "tests pass on retry".
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[cleanupTestDb] failed for ${testFileName} after ${maxRetries} attempts: ${error?.message ?? error}`
+        );
         return;
       }
-      // Wait before retry with exponential backoff
       const delay = Math.min(100 * Math.pow(2, attempt), 1000);
       await new Promise((resolve) => setTimeout(resolve, delay));
     }
   }
+  void lastError;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Diagnose 14 Windows embedded test failures (`Update execution failed`) by surfacing the real OB error/warning + ret code, and verifying cleanupTestDb actually removed the dir.
- Companion to the engine-side fix in oceanbase/seekdb feat/embedded-mode-1.3.0 (commit 252658b8).

## Why

Current Windows CI logs only show generic `Error: Update execution failed`. The real OB error code/message is dropped at the C ABI layer. Together with this PR's engine-side change (commit 252658b8 in seekdb), Windows CI will now print real OB error info, plus optional SQL+params preview when SEEKDB_DEBUG_SQL=1.

Also: cleanupTestDb on Windows used fs.rm with force:true which silently succeeds even when files are locked. Now it verifies via fs.access and warns.

## Test plan

- [ ] Wait for engine-side libseekdb rebuild from oceanbase/seekdb feat/embedded-mode-1.3.0 (commit 252658b8)
- [ ] Update LIBSEEKDB_URL_PREFIX after libseekdb is rebuilt
- [ ] Re-run CI and inspect Windows embedded test logs for real OB error code

🤖 Generated with [Claude Code](https://claude.com/claude-code)