### PR TITLE
fix(js-bindings): fix on-demand download on non-Windows and exclude native binaries from npm

### DIFF
--- a/packages/bindings/pkgs/js-bindings/download.js
+++ b/packages/bindings/pkgs/js-bindings/download.js
@@ -61,18 +61,20 @@ function prepareWin32BindingsDir(bindingsDir) {
   }
 }
 
-function isWin32BindingsDirReady(bindingsDir) {
-  if (process.platform !== "win32") return true;
-  return (
-    fs.existsSync(path.join(bindingsDir, "seekdb.node")) &&
-    fs.existsSync(path.join(bindingsDir, "seekdb.dll"))
-  );
+function isBindingsDirReady(bindingsDir) {
+  if (!fs.existsSync(path.join(bindingsDir, "seekdb.node"))) {
+    return false;
+  }
+  if (process.platform === "win32") {
+    return fs.existsSync(path.join(bindingsDir, "seekdb.dll"));
+  }
+  return true;
 }
 
 async function ensureBindingsDownloaded() {
   const cacheDir = getCacheDir();
   const nodePath = path.join(cacheDir, "seekdb.node");
-  if (isWin32BindingsDirReady(cacheDir)) {
+  if (isBindingsDirReady(cacheDir)) {
     prepareWin32BindingsDir(cacheDir);
     return cacheDir;
   }
@@ -94,7 +96,7 @@ async function ensureBindingsDownloaded() {
   if (!fs.existsSync(nodePath)) {
     throw new Error(`Zip did not contain seekdb.node: ${zipPath}`);
   }
-  if (!isWin32BindingsDirReady(cacheDir)) {
+  if (!isBindingsDirReady(cacheDir)) {
     throw new Error(
       `Zip missing Windows runtime (seekdb.node and seekdb.dll required): ${zipPath}`
     );

--- a/packages/bindings/pkgs/js-bindings/package.json
+++ b/packages/bindings/pkgs/js-bindings/package.json
@@ -4,6 +4,15 @@
   "license": "Apache-2.0",
   "main": "./seekdb.js",
   "types": "./seekdb.d.ts",
+  "files": [
+    "download.js",
+    "seekdb.js",
+    "seekdb.d.ts",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "prepublishOnly": "node -e \"const fs=require('fs');const p=require('path');const d=__dirname;for(const f of['seekdb.node','libseekdb.dylib','libseekdb.so','seekdb.dll']){try{fs.unlinkSync(p.join(d,f))}catch{}}const libs=p.join(d,'libs');if(fs.existsSync(libs))fs.rmSync(libs,{recursive:true,force:true});\""
+  },
   "exports": {
     ".": {
       "types": "./seekdb.d.ts",


### PR DESCRIPTION
## Summary

- Fix `ensureBindingsDownloaded()` returning an empty cache directory on Linux/macOS when `seekdb.node` is missing, because `isWin32BindingsDirReady()` unconditionally returned `true` on non-Windows platforms
- Restrict `@seekdb/js-bindings` npm publish to JS loader files only, preventing macOS arm64 binaries from being bundled into the package (per design: binaries are hosted on S3, not npm)

## Test plan

- [x] Simulated `linux-x64` with empty cache: `ensureBindingsDownloaded()` now downloads and extracts `seekdb.node` (ELF x86-64)
- [x] `npm pack --dry-run` shows only 5 files (~3.4 KB), no `.node` / `.dylib` artifacts
- [ ] Publish patch release and verify embedded mode on Linux x64 with fresh `npm install`


Made with [Cursor](https://cursor.com)